### PR TITLE
Fix: Parametrize Stopwords Language in label_sentence Function

### DIFF
--- a/unsupervised/produce_labeled_data.py
+++ b/unsupervised/produce_labeled_data.py
@@ -21,7 +21,7 @@ import click
 NORMALIZER = DateNormalizer()
 
 
-def label_sentence(entity_linking_results, debug, numerical):
+def label_sentence(entity_linking_results, debug, numerical, language='italian'):
     """Produce a labeled sentence by comparing the linked entities to the frame definition
 
     :param str entity_linking_results: path to JSON file containing the results of the
@@ -65,7 +65,7 @@ def label_sentence(entity_linking_results, debug, numerical):
                     assigned_fes = []
                     for diz in val:
                         # Filter out linked stopwords
-                        if diz['chunk'].lower() in stopwords.StopWords.words('italian'):
+                        if diz['chunk'].lower() in stopwords.StopWords.words(language):
                             continue
 
                         chunk = {


### PR DESCRIPTION
### Description
This pull request addresses the issue where Italian stopwords were hardcoded in the label_sentence function. The stopwords language is now parameterized, allowing for multilingual support and improved flexibility.

### Changes Made
- Added a language parameter to the label_sentence function.
- Updated the stopwords check to use the specified language dynamically.

**Testing**
Verified the functionality with different languages for stopwords.

**Related Issue**
https://github.com/dbpedia/fact-extractor/issues/88