### PR TITLE
Parameterize stopwords language in produce_labeled_data

### DIFF
--- a/unsupervised/produce_labeled_data.py
+++ b/unsupervised/produce_labeled_data.py
@@ -208,7 +208,7 @@ def process_dir(indir, debug, numerical,language):
 @click.option('--debug/--no-debug', default=False)
 @click.option('--numerical/--no-numerical', default=True)
 @click.option('--language', default='italian', help='Language for stopwords')
-def main(linked_dir, labeled_out, score, core_weight, score_fes, debug, numerical):
+def main(linked_dir, labeled_out, score, core_weight, score_fes, debug, numerical,language):
     """
     this script is the actual unsupervised approach which produces labeled data
     out of entity linked sentences

--- a/unsupervised/produce_labeled_data.py
+++ b/unsupervised/produce_labeled_data.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
+
 import os
 if __name__ == '__main__' and __package__ is None:
     os.sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -18,10 +19,11 @@ from lib.scoring import compute_score, AVAILABLE_SCORES
 import click
 
 
+
 NORMALIZER = DateNormalizer()
 
 
-def label_sentence(entity_linking_results, debug, numerical):
+def label_sentence(entity_linking_results, debug, numerical,language):
     """Produce a labeled sentence by comparing the linked entities to the frame definition
 
     :param str entity_linking_results: path to JSON file containing the results of the
@@ -65,7 +67,7 @@ def label_sentence(entity_linking_results, debug, numerical):
                     assigned_fes = []
                     for diz in val:
                         # Filter out linked stopwords
-                        if diz['chunk'].lower() in stopwords.StopWords.words('italian'):
+                        if diz['chunk'].lower() in stopwords.StopWords.words(language):
                             continue
 
                         chunk = {
@@ -172,7 +174,7 @@ def label_sentence(entity_linking_results, debug, numerical):
     return labeled
 
 
-def process_dir(indir, debug, numerical):
+def process_dir(indir, debug, numerical,language):
     """Walk into the input directory and process all the entity linking results,
     creating the labeled data
 
@@ -186,7 +188,7 @@ def process_dir(indir, debug, numerical):
     for path, subdirs, files in os.walk(indir):
         for name in files:
             f = os.path.join(path, name)
-            labeled = label_sentence(f, debug, numerical)
+            labeled = label_sentence(f, debug, numerical,language)
             # Filename is {WIKI_ID}.{SENTENCE_ID}(.{extension})?
             labeled['id'] = '.'.join(name.split('.')[:2])
 
@@ -205,12 +207,14 @@ def process_dir(indir, debug, numerical):
 @click.option('--score-fes/--no-score-fes', help='Score individual FEs')
 @click.option('--debug/--no-debug', default=False)
 @click.option('--numerical/--no-numerical', default=True)
+@click.option('--language', default='italian', help='Language for stopwords')
 def main(linked_dir, labeled_out, score, core_weight, score_fes, debug, numerical):
     """
     this script is the actual unsupervised approach which produces labeled data
     out of entity linked sentences
     """
-    labeled = process_dir(linked_dir, score_fes, debug, numerical)
+    labeled = process_dir(linked_dir, score_fes, debug, numerical, language)
+
 
     if score:
         for sentence in labeled:

--- a/verb_ranking/tf_idfize.py
+++ b/verb_ranking/tf_idfize.py
@@ -10,11 +10,14 @@ import json
 import regex
 import tfidf
 from collections import Counter, OrderedDict
+from lib.stopwords import StopWords
 
-STOPWORDS = ["ad", "al", "allo", "ai", "agli", "all", "agl", "alla", "alle", "con", "col", "coi", "d", "da", "dal", "dallo", "dai", "dagli", "dall", "dagl", "dalla", "dalle", "di", "del", "dello", "dei", "degli", "dell", "degl", "della", "delle", "in", "nel", "nello", "nei", "negli", "nell", "negl", "nella", "nelle", "su", "sul", "sullo", "sui", "sugli", "sull", "sugl", "sulla", "sulle", "per", "tra", "contro", "io", "tu", "lui", "lei", "noi", "voi", "loro", "mio", "mia", "miei", "mie", "tuo", "tua", "tuoi", "tue", "suo", "sua", "suoi", "sue", "nostro", "nostra", "nostri", "nostre", "vostro", "vostra", "vostri", "vostre", "mi", "ti", "ci", "vi", "lo", "la", "li", "le", "gli", "ne", "il", "un", "uno", "una", "ma", "ed", "se", "perché", "anche", "come", "dov", "dove", "che", "chi", "cui", "non", u"più", "quale", "quanto", "quanti", "quanta", "quante", "quello", "quelli", "quella", "quelle", "questo", "questi", "questa", "queste", "si", "tutto", "tutti", "a", "c", "e", "i", "l", "o", "ho", "hai", "ha", "abbiamo", "avete", "hanno", "abbia", "abbiate", "abbiano", u"avrò", "avrai", u"avrà", "avremo", "avrete", "avranno", "avrei", "avresti", "avrebbe", "avremmo", "avreste", "avrebbero", "avevo", "avevi", "aveva", "avevamo", "avevate", "avevano", "ebbi", "avesti", "ebbe", "avemmo", "aveste", "ebbero", "avessi", "avesse", "avessimo", "avessero", "avendo", "avuto", "avuta", "avuti", "avute", "sono", "sei", u"è", "siamo", "siete", "sia", "siate", "siano", u"sarò", "sarai", u"sarà", "saremo", "sarete", "saranno", "sarei", "saresti", "sarebbe", "saremmo", "sareste", "sarebbero", "ero", "eri", "era", "eravamo", "eravate", "erano", "fui", "fosti", "fu", "fummo", "foste", "furono", "fossi", "fosse", "fossimo", "fossero", "essendo", "faccio", "fai", "facciamo", "fanno", "faccia", "facciate", "facciano", u"farò", "farai", u"farà", "faremo", "farete", "faranno", "farei", "faresti", "farebbe", "faremmo", "fareste", "farebbero", "facevo", "facevi", "faceva", "facevamo", "facevate", "facevano", "feci", "facesti", "fece", "facemmo", "faceste", "fecero", "facessi", "facesse", "facessimo", "facessero", "facendo", "s", "sto", "stai", "sta", "stiamo", "stanno", "stia", "stiate", "stiano", u"starò", "starai", u"starà", "staremo", "starete", "staranno", "starei", "staresti", "starebbe", "staremmo", "stareste", "starebbero", "stavo", "stavi", "stava", "stavamo", "stavate", "stavano", "stetti", "stesti", "stette", "stemmo", "steste", "stettero", "stessi", "stesse", "stessimo", "stessero", "stando"]
 
 
-def compute_tfidf_matrix(corpus_dir):
+def compute_tfidf_matrix(corpus_dir,language):
+    sw = set(StopWords.words(language))
+
+
     t = tfidf.tfidf()
     for path, subdirs, files in os.walk(corpus_dir):
         for name in files:
@@ -23,10 +26,10 @@ def compute_tfidf_matrix(corpus_dir):
                 tokens = []
                 for line in i:
                     # Skip <doc> tags
-                    if not regex.match(ur'</?doc', line):
-                        l_tokens = regex.split(ur'[^\p{L}]+', line.lower())
-                        tokens += [token for token in l_tokens
-                                         if token and token not in STOPWORDS]
+                    if not regex.match(r'</?doc', line):
+                        l_tokens = regex.split(r'[^\p{L}]+', line.lower())
+                        tokens += [token for token in l_tokens if token and token not in sw]
+
                 t.addDocument(f, tokens)
     return t
 
@@ -63,6 +66,10 @@ def get_distributions(tokens, tfidf_matrix, threshold):
 
 
 @click.command()
+@click.option('--language', default='english',
+              help='Language for stopword filtering (default: english)')
+
+
 @click.argument('corpus', type=click.Path(exists=True, file_okay=False))
 @click.argument('tokens', type=click.File('r'))
 @click.option('--threshold', '-t', default=0.6)
@@ -71,19 +78,21 @@ def get_distributions(tokens, tfidf_matrix, threshold):
 @click.option('--stdevs-out', type=click.File('w'), default='stdevs.json')
 @click.option('--threshold-rank-out', type=click.File('w'), default='threshold_rank.json')
 @click.option('--tfidf-rank-out', type=click.File('w'), default='tfidf.json')
-def main(corpus, tokens, threshold, dump_tfidf, variance_out, stdevs_out,
-         threshold_rank_out, tfidf_rank_out):
+def main(language, corpus, tokens, threshold, dump_tfidf,
+         variance_out, stdevs_out, threshold_rank_out, tfidf_rank_out):
 
-    print "Loading tokens..."
+
+    print ("Loading tokens...")
     tokens = [token.strip() for token in tokens]
 
-    print "Building TF/IDF matrix against corpus %s ..." % corpus
-    t = compute_tfidf_matrix(corpus)
+    print ("Building TF/IDF matrix against corpus %s ..." % corpus)
+    t = compute_tfidf_matrix(corpus, language)
 
-    print "Computing variance, standard deviation, and ranking"
+
+    print ("Computing variance, standard deviation, and ranking")
     vars, stdevs, threshold_rank, tfidf_ranking = get_distributions(tokens, t, threshold)
 
-    print "Dumping results to JSON ..."
+    print ("Dumping results to JSON ...")
     json.dump(vars, variance_out, indent=2)
     json.dump(stdevs, stdevs_out, indent=2)
     json.dump(threshold_rank, threshold_rank_out, indent=2)

--- a/verb_ranking/tf_idfize.py
+++ b/verb_ranking/tf_idfize.py
@@ -14,7 +14,7 @@ from lib.stopwords import StopWords
 
 
 
-def compute_tfidf_matrix(corpus_dir,language):
+def compute_tfidf_matrix(corpus_dir, language):
     sw = set(StopWords.words(language))
 
 

--- a/verb_ranking/tfidf.py
+++ b/verb_ranking/tfidf.py
@@ -53,7 +53,7 @@ class tfidf:
             score = 0.0
             doc_dict = doc[1]
             for k in query_dict:
-                if doc_dict.has_key(k):
+                if k in doc_dict:
                     score += (query_dict[k] / self.corpus_dict[k]) + (doc_dict[k] / self.corpus_dict[k])
             sims.append([doc[0], score])
 


### PR DESCRIPTION
Fixes #88

This PR removes the hardcoded Italian stopwords in produce_labeled_data.py and allows users to specify the stopwords language via the CLI, making the pipeline multilingual and improving dataset quality.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added language support across labeling and TF‑IDF workflows so stopword filtering is language-aware.
  * New CLI option --language to choose stopword language (tool-specific defaults applied).

* **Improvements**
  * Tokenization and TF‑IDF pipeline modernized for more robust processing and Python 3 compatibility.
  * Language setting now propagates through processing for consistent, localized outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->